### PR TITLE
Made IP/MAC distribution as even as possible for droplets; added paramater in GET /default_setup API.

### DIFF
--- a/src/mgmt/manager/project/api/default_setup.py
+++ b/src/mgmt/manager/project/api/default_setup.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2022 The Authors.
 #
-# Authors: io Zhu <@zzxgzgz>
+# Authors: Rio Zhu <@zzxgzgz>
 #
 # Summary: default setup API
 #

--- a/src/mgmt/manager/project/api/nodes.py
+++ b/src/mgmt/manager/project/api/nodes.py
@@ -207,7 +207,7 @@ def set_up_node_from_hazelcast(arion_node: ArionNode):
             # sort these droplets in descending order, so droplet with the most IPs will be in the front.
             droplet_that_can_give_ip_mac.sort(key=lambda x : len(x['spec']['ip']), reverse=True)
             # only one IP/mac for other droplets
-            while len(ip_for_new_droplet) < 1:
+            while len(ip_for_new_droplet) < number_of_ip_new_droplet_gets:
                 for droplet in droplet_that_can_give_ip_mac:
                     droplet_spec = droplet['spec']
                     droplet_ip_list = droplet_spec['ip']
@@ -330,7 +330,7 @@ def all_nodes():
                 # sort these droplets in descending order, so droplet with the most IPs will be in the front.
                 droplet_that_can_give_ip_mac.sort(key=lambda x : len(x['spec']['ip']), reverse=True)
                 # only one IP/mac for other droplets
-                while len(ip_for_new_droplet) < 1:
+                while len(ip_for_new_droplet) < number_of_ip_new_droplet_gets:
                     for droplet in droplet_that_can_give_ip_mac:
                         droplet_spec = droplet['spec']
                         droplet_ip_list = droplet_spec['ip']


### PR DESCRIPTION
## NOTE: This is a duplicate of #4, this PR is created because #4 was closed by some error, and the old repo is no longer able to submit PRs to this repo.

This PR does the following:

Made the IP/MAC distribution as even as possible for Arion Wings.
Added ?use_arion_agent parameter to the /default_setup API. If set to true, the API does not program the Wings' eBPF maps, so that Arion Agent on each Wing can do it; otherwise, it programs each Wing's eBPF maps.